### PR TITLE
채팅방 액티비티 및 어댑터

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,5 +77,4 @@ dependencies {
     //glide
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     kapt 'com.github.bumptech.glide:compiler:4.11.0'
-
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,9 @@
             android:name=".ChatListActivity"
             android:exported="false" />
         <activity
-            android:name=".ChatRoomActivity"
+            android:name=".ChatRoom.ChatRoomActivity"
             android:exported="false"
-            android:parentActivityName=".ChatListActivity"/>
+            android:parentActivityName=".ChatListActivity" />
         <activity
             android:name=".Login.LoginActivity"
             android:exported="true" >
@@ -34,15 +34,6 @@
         <activity
             android:name=".Login.AuthActivity"
             android:exported="true" />
-        <activity
-            android:name=".MainActivity"
-            android:exported="true">
-<!--            <intent-filter>-->
-<!--                <action android:name="android.intent.action.MAIN" />-->
-
-<!--                <category android:name="android.intent.category.LAUNCHER" />-->
-<!--            </intent-filter>-->
-        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/chatting/ChatFragment/RvItemChatAdapter.kt
+++ b/app/src/main/java/com/example/chatting/ChatFragment/RvItemChatAdapter.kt
@@ -1,13 +1,12 @@
 package com.example.chatting.ChatFragment
 
 import android.content.Intent
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.example.chatting.ChatRoomActivity
+import com.example.chatting.ChatRoom.ChatRoomActivity
 import com.example.chatting.Model.UserRoom
 import com.example.chatting.MyApplication
 import com.example.chatting.R

--- a/app/src/main/java/com/example/chatting/ChatRoom/ChatRoomActivity.kt
+++ b/app/src/main/java/com/example/chatting/ChatRoom/ChatRoomActivity.kt
@@ -1,24 +1,25 @@
-package com.example.chatting
+package com.example.chatting.ChatRoom
 
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
+import android.view.WindowManager
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.chatting.Model.MessageData
+import androidx.recyclerview.widget.RecyclerView
 import com.example.chatting.Model.Messages
 import com.example.chatting.Model.UserRoom
+import com.example.chatting.MyApplication
+import com.example.chatting.R
 import com.example.chatting.databinding.ActivityChatRoomBinding
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.ktx.database
-import com.google.firebase.firestore.auth.User
 import com.google.firebase.ktx.Firebase
 import java.lang.Exception
 
@@ -33,25 +34,32 @@ class ChatRoomActivity : AppCompatActivity() {
     private val UserRoom = mutableListOf<UserRoom>()
     lateinit var adapter : ChatRoomAdatpter
     lateinit var binding: ActivityChatRoomBinding
-    var messageData = mutableListOf<MessageData>()
+    lateinit var myRecyclerView: RecyclerView
 
     @SuppressLint("NotifyDataSetChanged")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         binding = ActivityChatRoomBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-
         try {
             userName = intent.getSerializableExtra("userName") as String
             binding.toolbar.setTitle(userName)
         } catch (e:Exception){}
         try { userEmail = intent.getSerializableExtra("userEmail") as String }catch (e:Exception){}
-        try{ chatRoomId = intent.getStringExtra("chatRoomId") as String } catch (e:Exception){}
+        try { chatRoomId = intent.getStringExtra("chatRoomId") as String } catch (e:Exception){}
+
+
+        myRecyclerView = binding.rvChatroom
+        adapter = ChatRoomAdatpter(Messages)
+        binding.rvChatroom.adapter = adapter
+        binding.rvChatroom.layoutManager = LinearLayoutManager(this)
         loadChatData()
+
 
         binding.etMessage.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
@@ -82,11 +90,7 @@ class ChatRoomActivity : AppCompatActivity() {
                 }
             }
         })
-
-        adapter = ChatRoomAdatpter(Messages)
-        binding.rvChatroom.adapter = adapter
-        binding.rvChatroom.layoutManager = LinearLayoutManager(this)
-
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         binding.btnSend.setOnClickListener{
             val msg = binding.etMessage.text.toString()   //msg
             val time = System.currentTimeMillis()
@@ -97,7 +101,7 @@ class ChatRoomActivity : AppCompatActivity() {
                     sender = MyApplication.auth.currentUser?.email.toString()
                 )
                 val userRoom = UserRoom(
-                    chatroomid = chatRoomId!!,
+                    //chatroomid = chatRoomId!!,
                     lastmessage = msg,
                     timestamp = time ,
                     sender = MyApplication.auth.currentUser?.email.toString()
@@ -106,7 +110,8 @@ class ChatRoomActivity : AppCompatActivity() {
                 Messages.add(messageData)
                 UserRoom.add(userRoom)
                 messageRef.child("$chatRoomId").push().setValue(messageData)
-                userRoomRef.child("$chatRoomId").push().setValue(userRoom)
+                userRoomRef.child("$chatRoomId").setValue(userRoom)
+                myRecyclerView.scrollToPosition(adapter.itemCount-1)
             }
         }
     }
@@ -142,6 +147,8 @@ class ChatRoomActivity : AppCompatActivity() {
                         }
                     }
                 }
+                adapter.notifyDataSetChanged()
+                myRecyclerView.scrollToPosition(adapter.itemCount-1)
             }
             override fun onCancelled(error: DatabaseError) {
                 Log.d("grusie","failed")

--- a/app/src/main/java/com/example/chatting/ChatRoom/ChatRoomAdatpter.kt
+++ b/app/src/main/java/com/example/chatting/ChatRoom/ChatRoomAdatpter.kt
@@ -1,20 +1,13 @@
-package com.example.chatting
+package com.example.chatting.ChatRoom
 
-import android.content.ClipData
 import android.content.Context
-import android.content.Intent
-import android.graphics.Color
-import android.os.Build
-import android.os.Parcelable
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.Toast
-import androidx.annotation.RequiresApi
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.chatting.Model.Messages
+import com.example.chatting.MyApplication
+import com.example.chatting.R
 import com.example.chatting.databinding.ItemReceivemsgBinding
 import com.example.chatting.databinding.ItemSendmsgBinding
 import java.lang.RuntimeException

--- a/app/src/main/java/com/example/chatting/Model/MessageData.kt
+++ b/app/src/main/java/com/example/chatting/Model/MessageData.kt
@@ -1,11 +1,7 @@
 package com.example.chatting.Model
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-
-@Parcelize
 data class MessageData(
     var message: String,
     var sender: String,
     var timestamp: Long
-): Parcelable
+)

--- a/app/src/main/java/com/example/chatting/Model/UserData.kt
+++ b/app/src/main/java/com/example/chatting/Model/UserData.kt
@@ -1,7 +1,7 @@
 package com.example.chatting.Model
 
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class UserData(
@@ -9,4 +9,4 @@ data class UserData(
     var name: String,
     var statusMsg: String,
     var profileMusic: String
-) : Parcelable
+): Parcelable

--- a/app/src/main/java/com/example/chatting/Model/UserRoom.kt
+++ b/app/src/main/java/com/example/chatting/Model/UserRoom.kt
@@ -1,13 +1,11 @@
 package com.example.chatting.Model
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-
 //마지막 메시지
-@Parcelize
 data class UserRoom(
-    var chatroomid: String,
+    var chatroomid: String?,
     var lastmessage: String,
     var timestamp: Long,
     var sender: String
-): Parcelable
-
+) {
+    constructor(lastmessage: String, timestamp: Long, sender: String)
+            : this(null, lastmessage, timestamp, sender)
+}

--- a/app/src/main/java/com/example/chatting/Model/chatRoomUser.kt
+++ b/app/src/main/java/com/example/chatting/Model/chatRoomUser.kt
@@ -1,11 +1,8 @@
 package com.example.chatting.Model
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
 
 //채팅방별 유저
-@Parcelize
 data class chatRoomUser(
     var user1: String,
     var user2: String
-): Parcelable
+)
 

--- a/app/src/main/java/com/example/chatting/ProfileDetail/MyProfileDetailActivity.kt
+++ b/app/src/main/java/com/example/chatting/ProfileDetail/MyProfileDetailActivity.kt
@@ -12,8 +12,7 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
-import com.example.chatting.ChatRoomActivity
-import com.example.chatting.Model.Messages
+import com.example.chatting.ChatRoom.ChatRoomActivity
 import com.example.chatting.Model.UserData
 import com.example.chatting.Model.chatRoomUser
 import com.example.chatting.MyApplication
@@ -311,7 +310,7 @@ class MyProfileDetailActivity : AppCompatActivity() {
                         user1 = null
                         user2 = null
                         for (chatRoomUserData in chatRoomInfo.children) {
-                            if (chatRoomUserData.value == MyApplication.auth.currentUser?.email) {
+                            if (user1 == null && chatRoomUserData.value == MyApplication.auth.currentUser?.email) {
                                 user1 = chatRoomUserData.value as String
                             } else if (chatRoomUserData.value == userData.email) {
                                 user2 = chatRoomUserData.value as String

--- a/app/src/main/res/layout/activity_chat_room.xml
+++ b/app/src/main/res/layout/activity_chat_room.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ChatRoomActivity">
+    tools:context=".ChatRoom.ChatRoomActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"

--- a/app/src/main/res/menu/menu_chat_room.xml
+++ b/app/src/main/res/menu/menu_chat_room.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.example.chatting.ChatRoomActivity" >
+    tools:context="com.example.chatting.ChatRoom.ChatRoomActivity" >
 
     <group>
         <item


### PR DESCRIPTION
채팅방 들어갔을 때, 채팅 내역 바로 안 뜨던 부분 수정
(+채팅 내용 맨 밑부분 띄워줌)
나와의 채팅 눌렀을 때 리얼타임데이터베이스에 계속 정보 추가되던 부분 수정
메세지 보냈을 때 맨 밑에 부분으로 스크롤 되도록 수정