### PR TITLE
12.29 수정사항

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="R3CM504FPGE" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2021-12-29T10:30:03.754819500Z" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/chatting/ChatRoomAdatpter.kt
+++ b/app/src/main/java/com/example/chatting/ChatRoomAdatpter.kt
@@ -99,4 +99,9 @@ class ChatRoomAdatpter(var messages : MutableList<Messages>) : RecyclerView.Adap
         if(messages!=null) return messages.size
         else return 0
     }
+
+    fun removeItem(removeMsg: Messages){
+        messages.remove(removeMsg)
+        notifyDataSetChanged()
+    }
 }

--- a/app/src/main/java/com/example/chatting/Model/Messages.kt
+++ b/app/src/main/java/com/example/chatting/Model/Messages.kt
@@ -1,7 +1,7 @@
 package com.example.chatting.Model
 
 data class Messages(
-    val message: String,
-    val timestamp: Long,
-    val sender: String,
+    var message: String = "",
+    var timestamp: Long = 0,
+    var sender: String = "",
 )


### PR DESCRIPTION
실시간 채팅 기능 수정
- LoadChatData() 함수 수정
 = ValueEventListener -> childEventListener를 사용함
 = childEventListener 내의 removed 기능 보완 -> 채팅방 액티비티 켜져있을 시, 리얼타임 데이터베이스에서 데이터 삭제 시 어뎁터에 remove 시킴 -> 이걸 하지 않으면, 데이터 삭제 시 에러 남

 날짜 띄우는 부분 수정
 - lastDate를 전역변수로 사용하여, 채팅이 추가될 때 그 전 타임스탬프를 넣고, null값 예외처리 함
 - currentDate는 채팅 보낼 시 받아와서 넣어주고
 - 데이터 추가 시 dateCalc() 호출
 - 첫번 째 채팅이 입력될 시(lasteDate == null) 당일 날짜 띄워주고,
 - 그렇지 않다면 매 번 lastDate와 currentDate 비교

 Messages 클래스 변수들 val로 되어 있던 것 var로 수정
 -> childEventListener로 데이터 불러올 시 에러가 뜨기 때문에 수정