### PR TITLE
1/14 수정 및 추가

### DIFF
--- a/app/src/main/java/com/example/chatting/ChatFragment/RvItemChatAdapter.kt
+++ b/app/src/main/java/com/example/chatting/ChatFragment/RvItemChatAdapter.kt
@@ -1,8 +1,6 @@
 package com.example.chatting.ChatFragment
 
-import android.annotation.SuppressLint
 import android.content.Intent
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,7 +8,6 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.chatting.ChatRoomActivity
-import com.example.chatting.Model.Messages
 import com.example.chatting.Model.UserRoom
 import com.example.chatting.MyApplication
 import com.example.chatting.R
@@ -19,7 +16,6 @@ import com.google.firebase.database.ChildEventListener
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ktx.getValue
-import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -33,11 +29,14 @@ class RvItemChatViewHolder(val binding: RvitemChatBinding) : RecyclerView.ViewHo
                     for (field in document) tvChatUsername.text = field["name"] as String
                 }
 
-            val imgRefProfile = MyApplication.storage.reference.child("${data.sender}/profile")
-            Glide.with(binding.root.context)
-                .load(imgRefProfile)
-                .error(R.drawable.img_profile)
-                .into(ivChatProfile)
+            MyApplication.storage.reference.child("${data.sender}/profile")
+                .downloadUrl
+                .addOnSuccessListener {
+                    Glide.with(binding.root.context)
+                        .load(it)
+                        .error(R.drawable.img_profile)
+                        .into(ivChatProfile)
+                }
 
             tvChatPreviewmsg.text = data.lastmessage
 
@@ -71,22 +70,22 @@ class RvItemChatViewHolder(val binding: RvitemChatBinding) : RecyclerView.ViewHo
     }
 
     //Update LastMessage Information
-    fun updateChat(chatroomid: String) {
+    private fun updateChat(chatRoomID: String) {
         val chatRoomListener = object : ChildEventListener {
             override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {
             }
 
             override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) {
-                if(snapshot.key == chatroomid) {
-                    var lastmessage = ""
+                if(snapshot.key == chatRoomID) {
+                    var lastMessage = ""
                     var timestamp: Long = 0
                     val userRoomData = snapshot.getValue<UserRoom>()!!
-                    lastmessage = userRoomData.lastmessage
+                    lastMessage = userRoomData.lastmessage
                     timestamp = userRoomData.timestamp
 
-                    binding.tvChatPreviewmsg.text = lastmessage
+                    binding.tvChatPreviewmsg.text = lastMessage
                     dateCalc(timestamp)
-                    getChatNum(chatroomid)
+                    getChatNum(chatRoomID)
                 }
             }
 
@@ -158,7 +157,7 @@ class RvItemChatAdapter(var chatData: MutableList<UserRoom>) :
         holder.setData(data)
 
         holder.itemView.setOnClickListener {
-            val intent = Intent(holder.itemView?.context, ChatRoomActivity::class.java)
+            val intent = Intent(holder.itemView.context, ChatRoomActivity::class.java)
             intent.putExtra("chatRoomId", data.chatroomid)
             intent.putExtra("userName", holder.getUsername())
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/com/example/chatting/ChatRoomActivity.kt
+++ b/app/src/main/java/com/example/chatting/ChatRoomActivity.kt
@@ -134,7 +134,11 @@ class ChatRoomActivity : AppCompatActivity() {
                 chatRoomUserRef.child(chatRoomId!!)
                     .get()
                     .addOnSuccessListener {
+                        val userList = mutableListOf<String>()
+
                         for (user in it.children){
+                            //본인이 아닌 다른 사람의 In Out 여부를 확인 후 read = true/false 결정
+                                // -> 본인과의 대화이면 if 문에 해당 X
                             if(user.value != MyApplication.auth.currentUser?.email){
                                 userStatusRef.child(chatRoomId!!).child(user.key!!)
                                     .get()
@@ -152,6 +156,16 @@ class ChatRoomActivity : AppCompatActivity() {
                                         myRecyclerView.scrollToPosition(adapter.itemCount-1)
                                     }
                             }
+                            userList.add(user.value as String)
+                        }
+
+                        if(userList[0] == userList[1]){
+                            val msg = messageData.copy(read = true)
+                            messageRef.child("$chatRoomId").child(key!!).setValue(msg)
+                            userRoomRef.child("$chatRoomId").setValue(userRoom)
+                            adapter.notifyDataSetChanged()
+                            currentDate = messageData.timestamp
+                            myRecyclerView.scrollToPosition(adapter.itemCount-1)
                         }
                     }
             }

--- a/app/src/main/java/com/example/chatting/FirebaseMessageService.kt
+++ b/app/src/main/java/com/example/chatting/FirebaseMessageService.kt
@@ -1,6 +1,13 @@
 package com.example.chatting
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.example.chatting.Model.ServerMsg
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
@@ -8,9 +15,93 @@ class FirebaseMessageService : FirebaseMessagingService() {
     override fun onNewToken(p0: String){
             Log.d("grusie", "Refreshed token: $p0")
     }
+
     override fun onMessageReceived(p0: RemoteMessage){
         super.onMessageReceived(p0)
         Log.d("grusie", "fcm message : ${p0.notification}")
         Log.d("grusie","fcm message : ${p0.data}")
+
+        val serverData = p0.data as Map<String, String>
+
+        val chatRoomId = serverData["ChatRoomID"]
+        Log.d("test", chatRoomId ?: "nothing")
+
+        val serverMsg = ServerMsg(
+            "name",
+            "text",
+            0
+        )
+
+        MyApplication.realtime.child("UserRoom").child(chatRoomId!!)
+            .get()
+            .addOnSuccessListener { dataSnapShot ->
+                for (info in dataSnapShot.children){
+                    when(info.key){
+                        "lastmessage" -> {
+                            serverMsg.text = info.value as String
+                        }
+
+                        "timestamp" -> {
+                            serverMsg.timestamp = info.value as Long
+                        }
+
+                        "sender" -> {
+                            val sender = info.value as String
+                            Log.d("Test", sender)
+                            MyApplication.db.collection("profile").document(sender)
+                                .get()
+                                .addOnSuccessListener { documentSnapShot ->
+                                    Log.d("test", "success")
+                                    serverMsg.name = documentSnapShot.getString("name")!!
+                                    Log.d("test", serverMsg.toString())
+                                    notifyMessage(serverMsg)
+                                }
+                        }
+                    }
+                }
+            }
+
+
+    }
+
+    private fun notifyMessage(message: ServerMsg){
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val builder: NotificationCompat.Builder
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelId = "Receive Message"
+            val channelName = "chatRoomID"
+            val importance = NotificationManager.IMPORTANCE_HIGH
+            val channel =
+                NotificationChannel(channelId, channelName, importance).apply {
+                    description = "New Message"
+                    setShowBadge(true)
+                }
+
+            // NotificationManager에 채널 등록
+            manager.createNotificationChannel(channel)
+
+            // 채널 이용해 빌더 생성
+            builder = NotificationCompat.Builder(this, channelId)
+        } else {
+            builder = NotificationCompat.Builder(this)
+        }
+
+        builder.apply {
+            setSmallIcon(android.R.drawable.ic_notification_overlay)  //스몰 아이콘
+            setContentTitle(message.name)
+            setContentText(message.text)
+            setWhen(message.timestamp)
+
+            val newMessageCount = 3
+            setNumber(newMessageCount)
+
+            val chatRoomIntent = Intent(this@FirebaseMessageService, ChatRoomActivity::class.java)
+            val pendingIntent =
+                PendingIntent.getActivity(this@FirebaseMessageService, 10, chatRoomIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+            setContentIntent(pendingIntent)
+        }
+
+        manager.notify(10, builder.build())
     }
 }

--- a/app/src/main/java/com/example/chatting/Model/ServerMsg.kt
+++ b/app/src/main/java/com/example/chatting/Model/ServerMsg.kt
@@ -1,0 +1,7 @@
+package com.example.chatting.Model
+
+data class ServerMsg(
+    var name: String,
+    var text: String,
+    var timestamp: Long,
+)

--- a/app/src/main/java/com/example/chatting/ProfileDetail/MyProfileDetailActivity.kt
+++ b/app/src/main/java/com/example/chatting/ProfileDetail/MyProfileDetailActivity.kt
@@ -1,7 +1,6 @@
 package com.example.chatting.ProfileDetail
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -24,9 +23,6 @@ import com.example.chatting.R
 import com.example.chatting.databinding.ActivityMyProfileDetailBinding
 import com.example.chatting.util.URIPathHelper
 import com.example.chatting.util.myCheckPermission
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import java.io.File
@@ -38,9 +34,9 @@ class MyProfileDetailActivity : AppCompatActivity() {
     private lateinit var filename: String
     private val chatRoomRef = Firebase.database.getReference("chatRoomUser")
     private val userStatusRef = Firebase.database.getReference("UserStatus")
-    var chatRoomId: String? = null
-    var user1: String? = null
-    var user2: String? = null
+    private var chatRoomId: String? = null
+    private var user1: String? = null
+    private var user2: String? = null
     private lateinit var galleryIntent: ActivityResultLauncher<Intent>
     private var profileImgFilePath: String? = null
     private var backgroundImgFilePath: String? = null
@@ -51,7 +47,7 @@ class MyProfileDetailActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         //리사이클러 뷰 항목 클릭시 넘어온 userData 정보를 화면 뷰에 구성
-        userData = intent.getParcelableExtra<UserData>("userData")!!
+        userData = intent.getParcelableExtra("userData")!!
         Log.d("test", userData.toString())
         editState(checkProfileUser())
         binding()
@@ -342,7 +338,7 @@ class MyProfileDetailActivity : AppCompatActivity() {
 
             imgRef
                 .putFile(file)
-                .addOnSuccessListener { taskSnapShot ->
+                .addOnSuccessListener {
                     Toast.makeText(this, "사진이 저장되었습니다.", Toast.LENGTH_SHORT).show()
 
                     setImages()
@@ -350,14 +346,6 @@ class MyProfileDetailActivity : AppCompatActivity() {
                 .addOnFailureListener {
                     Log.d("grusie", "error : $it")
                 }
-        }
-
-        private fun openChatRoom(context: Context) {
-            val intent = Intent(context, ChatRoomActivity::class.java)
-            intent.putExtra("userName", binding.myProfileName.text.toString())
-            intent.putExtra("userEmail", userData.email)
-            intent.putExtra("chatRoomId", chatRoomId)
-            startActivity(intent)
         }
 
         private fun createChatRoom() {
@@ -377,18 +365,20 @@ class MyProfileDetailActivity : AppCompatActivity() {
                         chatRoomId = chatRoomInfo.key
                         break
                     }
+
                 }
+
                 if (chatRoomId == null) {
                     createChatRoomData()
+                } else {
+                    openChatRoom()
                 }
-                else openChatRoom(this@MyProfileDetailActivity)
             }
         }
 
     private fun createChatRoomData() {
         //랜덤 key 발급
-        val key = chatRoomRef.push().key
-        Log.d("test",  key!!)
+        val key = chatRoomRef.push().key!!
 
         //chatRoomUser 생성
         val chatRoomUserdata = chatRoomUser(
@@ -405,5 +395,19 @@ class MyProfileDetailActivity : AppCompatActivity() {
         userStatusRef.child(key).setValue(userStatusData)
 
         Toast.makeText(applicationContext, "채팅방 생성 완료", Toast.LENGTH_SHORT).show()
+
+        val intent = Intent(this@MyProfileDetailActivity, ChatRoomActivity::class.java)
+        intent.putExtra("userName", binding.myProfileName.text.toString())
+        intent.putExtra("userEmail", userData.email)
+        intent.putExtra("chatRoomId", key)
+        startActivity(intent)
+    }
+
+    private fun openChatRoom() {
+        val intent = Intent(this@MyProfileDetailActivity, ChatRoomActivity::class.java)
+        intent.putExtra("userName", binding.myProfileName.text.toString())
+        intent.putExtra("userEmail", userData.email)
+        intent.putExtra("chatRoomId", chatRoomId)
+        startActivity(intent)
     }
 }


### PR DESCRIPTION
-채팅방 생성 후 바로 입장
프로필에서 채팅하지 않은 상대 채팅방 눌렀을 때 생성 후 바로 입장할 수 있도록 수정

-나와 채팅하기 메세지 표시
메시지 실시간 확인 수정하면서 나와 채팅하기에서 메세지 표시가 안되는 오류 수정

-포그라운드시 메세지 알림 띄우기
앱이 포그라운드일 때 서버에서 메시지가 올 경우 onMessageReceived 에서 받은 data를 가공해서
상대방 이름, 마지막 메세지 내용, 마지막 메세지 타임스탬프를 앱 내에서 알림으로 띄움

-ChatFragment 이미지 에러 수정
chatFragment에서 이미지가 옛날 이미지로 뜨는 오류 수정 -> myProfileDetailActivity나 userFragment에서 한 것처럼 downloadurl 사용